### PR TITLE
WIP: Empty orders - front

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,15 +1,12 @@
 {
   "name": "my-account",
-  "vendor": "vtex",
-  "version": "1.25.0",
+  "vendor": "thefoschini",
+  "version": "0.0.0",
   "title": "My Account",
   "description": "User's my account page.",
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "dependencies": {
     "vtex.my-cards": "1.x",
-    "vtex.my-orders-app": "3.x",
     "vtex.my-account-commons": "1.x",
     "vtex.store-graphql": "2.x",
     "vtex.styleguide": "9.x",

--- a/node/package.json
+++ b/node/package.json
@@ -22,7 +22,7 @@
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.138.0/public/@types/vtex.styleguide"
   },
   "dependencies": {
-    "@vtex/api": "6.45.3"
+    "@vtex/api": "6.45.6"
   },
   "version": "1.25.0"
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -210,10 +210,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.45.3":
-  version "6.45.3"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.3.tgz#fe7d08adb4eab1fda5e34143cc6302a4c5aa5f52"
-  integrity sha512-kiD7We1TCKDyBdpYoh2Se3An+jTJRUzXGNpKifoDZylWQ1PyIx+3oL5ZAif9InlY3uJkfEisSAI6nxoKTgvPfw==
+"@vtex/api@6.45.6":
+  version "6.45.6"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.6.tgz#e5f08476d7c76f26baa1c040666d1364bdd6bc35"
+  integrity sha512-9pDiUxcUzq8RZa9yBex4C8dcAHXBRGAZokvHJ6sykrojq6mJxs+rUTE28TPeeQxwvvKsvrdpsfCUAYQ+UDz+zA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/package.json
+++ b/package.json
@@ -36,5 +36,5 @@
     "prettier": "^2.2.0",
     "typescript": "^3.7.5"
   },
-  "version": "1.11.1"
+  "version": "0.0.0"
 }

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -9,14 +9,9 @@
     ]
   },
   "my-account-menu": {
-    "blocks": [
-      "my-profile-link",
-      "my-addresses-link",
-      "my-orders-link",
-      "my-cards-link"
-    ]
+    "blocks": ["my-profile-link", "my-addresses-link", "my-cards-link"]
   },
   "my-account-pages": {
-    "blocks": ["my-orders", "my-cards"]
+    "blocks": ["my-cards"]
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -14,7 +14,7 @@
     "component": "DefaultPage"
   },
   "my-account-pages": {
-    "allowed": ["my-orders", "my-cards", "my-account-page"]
+    "allowed": ["my-cards", "my-account-page"]
   },
   "my-account-page": {
     "component": "*",
@@ -24,7 +24,6 @@
     "allowed": [
       "my-profile-link",
       "my-addresses-link",
-      "my-orders-link",
       "my-cards-link",
       "my-account-link"
     ]


### PR DESCRIPTION
### What problem is this solving?
see my orders on My Account using custom data from TFG system, in thsi case only show Empty Orders (default screen)

### How it works:

Login and go to Orders menu
If the user does not have confirmed orders, they should see an informative message and a button that takes them to the main page store

#### How to test it?

Login and go to Orders menu, the user should see a spinner and then a message with a button
[Workspace](https://tlva71--thefoschini.myvtex.com/account#/orders)

### Screenshots/Video example usage:

https://user-images.githubusercontent.com/84771232/156757090-6d2383db-ee0c-47af-b2df-1066af85c4da.mp4


### Related to / Depends on

[vtex-shop](https://github.com/TFG-Labs/vtex-shop/pull/64)
[Store](https://github.com/TFG-Labs/store/pull/1)
[tfg-custom-components](https://github.com/TFG-Labs/tfg-custom-components/pull/2)


### How does this PR make you feel? 🔗
![](https://media.giphy.com/media/k8kITi9SAwe9JWbUaH/giphy.gif)